### PR TITLE
Replaced "Grunt" with "Gulp"

### DIFF
--- a/oasp4js/index.html
+++ b/oasp4js/index.html
@@ -69,7 +69,7 @@
     <div class="row">
         <div class="col-md-6">
             <h1>Application Template</h1>
-            <p>oasp4js offers you a template for building JavaScript client applications. The application template defines a structure as well as integrates best-in-class frameworks, libraries and oasp4js extensions (as AngularJS modules). In addition to this, the template includes a Grunt script which supports developers in their activities such as coding, testing and building the application. The application built from the template looks like <a target="_blank" href="app-template">this</a></p>
+            <p>oasp4js offers you a template for building JavaScript client applications. The application template defines a structure as well as integrates best-in-class frameworks, libraries and oasp4js extensions (as AngularJS modules). In addition to this, the template includes a Gulp script which supports developers in their activities such as coding, testing and building the application. The application built from the template looks like <a target="_blank" href="app-template">this</a></p>
             <p><a class="btn btn-default" href="https://github.com/oasp/oasp4js-app-template" role="button"><img src="../img/GitHub-Mark-32px.png">&nbsp;&nbsp;View details &raquo;</a></p>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
Replaced "Grunt" with "Gulp" in the text below the "Application Template" heading on the main page of OASP4JS, i.e. on this page: http://oasp.github.io/oasp4js